### PR TITLE
Allow terrascan checks to fail

### DIFF
--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -92,7 +92,6 @@ jobs:
           iac_dir: "./infra"
           iac_version: "v14"
           policy_type: "all"
-          only_warn: true
 
   terrascan-production:
     name: "Terrascan Production Checks"
@@ -112,7 +111,6 @@ jobs:
           iac_dir: "./infra/production"
           iac_version: "v14"
           policy_type: "all"
-          only_warn: true
 
   checkov-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove `only_warn` from terrascan checks in Github Actions to allow it to fail on policy violations.