### PR TITLE
Allow Terraform principal to remove Key Vault

### DIFF
--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -2,6 +2,11 @@ data "tfe_ip_ranges" "addresses" {}
 
 data "azurerm_client_config" "current" {}
 
+data "azuread_group" "admin" {
+  display_name     = "Admin"
+  security_enabled = true
+}
+
 resource "random_string" "raw_data_db_password" {
   length           = 20
   override_special = "*()-_=+[]{}<>"
@@ -61,18 +66,42 @@ resource "azurerm_key_vault" "raw-data" {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azurerm_client_config.current.object_id
 
+    secret_permissions = [
+      "Set",
+      "Get",
+      "List",
+      "Delete",
+      "Purge"
+    ]
+
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azuread_group.admin.object_id
+
     key_permissions = [
       "List",
       "Get",
+      "Delete",
+      "Purge",
+      "Rotate"
     ]
 
     secret_permissions = [
       "Set",
       "Get",
       "List",
+      "Delete",
+      "Purge"
     ]
 
     storage_permissions = [
+      "Get",
+      "Set",
+      "List",
+      "Purge",
+      "Update"
     ]
   }
 

--- a/infra/production/provider.tf
+++ b/infra/production/provider.tf
@@ -10,6 +10,11 @@ terraform {
   }
 
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "=2.36.0"
+    }
+
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "=3.46.0"
@@ -28,6 +33,9 @@ terraform {
   }
 }
 
+provider "azuread" {
+  tenant_id = var.azure_tenant_id
+}
 
 provider "azurerm" {
   features {}


### PR DESCRIPTION
- Allow Terraform's service principal to purge Azure Key Vault entries and delete the vault itself. Currently, the key vault permissions set by terraform does not allow Delete permission for secrets. This is fixed. So terraform service principal that can create the vault and entries can also remove the vault.

- Add Admin AD group to manage Key Vault and entries. Added AzureAD provider for this reason.

TODO:
Currently, the permissions given are dangerous. Limit and restrict to baseline complying with principles of least privilege. So basically, Set and Update permissions for secrets management and Delete and purge for cleanup.