### PR TITLE
Remove AD provider in favour of variable

### DIFF
--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -2,11 +2,6 @@ data "tfe_ip_ranges" "addresses" {}
 
 data "azurerm_client_config" "current" {}
 
-data "azuread_group" "admin" {
-  display_name     = "Admin"
-  security_enabled = true
-}
-
 resource "random_string" "raw_data_db_password" {
   length           = 20
   override_special = "*()-_=+[]{}<>"
@@ -78,7 +73,7 @@ resource "azurerm_key_vault" "raw-data" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azuread_group.admin.object_id
+    object_id = var.azuread_admin_group_object_id
 
     key_permissions = [
       "List",

--- a/infra/production/provider.tf
+++ b/infra/production/provider.tf
@@ -10,11 +10,6 @@ terraform {
   }
 
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "=2.36.0"
-    }
-
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "=3.46.0"
@@ -31,10 +26,6 @@ terraform {
     }
 
   }
-}
-
-provider "azuread" {
-  tenant_id = var.azure_tenant_id
 }
 
 provider "azurerm" {

--- a/infra/production/variables.tf
+++ b/infra/production/variables.tf
@@ -61,3 +61,8 @@ variable "ssh_public_key" {
   default     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDqvEc1ESPkG7z2lBX2xYg1fsjXq+JNlcFJdEYtP2SKaVg8Vt0q4/oPBZSHN4p74oHZLEAF//2uFFbqADSvZYRtXIAdp78KvKGXo0Gkqd1pyf0ZPk4kEsfQfxcGeNYmT2T5I1ciYEdpbNgMv9C+WMdXZg0qZhOrgoAeJ6cudsBMtrJu3TTf6At3VELWqB0wL8fMHAfhDxy2+nojitp2OC20y9vAzwg8Uwpv+hVtjf19pijWT5i3gZspNYh+QxsZm+iPzhsD0E40Yi5UH/sqHmulbRYdlbemybeV4XoPEzcZ9UZHTQNXE3yvM592k7AxKHKdhr0y8qL+YzuO3Q0OCmxLtK9iQSchtBvnjhWqQQFfQoVxe+W/Yz0woKzy6+tixZOaTuTio2c23SQrAozTCIEpUkmDpv38FJXDAPl0Emsd5cUWyI2kcyq642B2jKZaKIZgJ0DBlbo7n1TIFYoBRYSa+wDQJ6VkMhNWVOhOBZ6ugu2wOFUe9BU2Q8Fd68hCSc="
   description = "Content of SSH Key public component"
 }
+
+variable "azuread_admin_group_object_id" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
Remove AzureAD provider in favour of a simple variable. In an attempt to create "clean code", AzureAD provider was used to fetch the object_id of an admin AD-group. But this proved more complicated than expected.

The AD provider was removed in this change and a variable with an empty default is being used for fetching object ID of the admin group. This variable was set in the variable-sets feature in Terraform cloud