### PR TITLE
Secure database by making it private

### DIFF
--- a/infra/staging/provider.tf
+++ b/infra/staging/provider.tf
@@ -34,7 +34,7 @@ provider "azurerm" {
   client_secret   = var.azure_client_secret
   tenant_id       = var.azure_tenant_id
 
-  features { }
+  features {}
 }
 
 provider "random" {


### PR DESCRIPTION
- Secure the database by moving from public access to private VNet access.
- Created a delegated subnet just for the database and added the flexible server to it - along with private DNS zone
- Create database in the server along with the host itself

TODO:
- Add tags using locals for all resources that will take them
- Add monitoring for VM, Redis cache and database
- Add documentation for infrastructure
- Increase VM disk space