### PR TITLE
Add Newrelic Agent as a VM extension

### DIFF
--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -254,6 +254,21 @@ resource "azurerm_virtual_machine_data_disk_attachment" "backend-volume" {
   caching            = "None"
 }
 
+resource "azurerm_virtual_machine_extension" "newrelic-infra-agent" {
+  name                       = "hostname"
+  virtual_machine_id         = azurerm_linux_virtual_machine.raw-data-backend.id
+  publisher                  = "NewRelic.Infrastructure.Extensions"
+  type                       = "newrelic-infra"
+  type_handler_version       = "1.2.9"
+  auto_upgrade_minor_version = true
+  automatic_upgrade_enabled  = true
+  settings = jsonencode(
+    {
+      "NR_LICENSE_KEY" = var.newrelic_license_key
+    }
+  )
+}
+
 resource "azurerm_private_dns_zone" "raw-data-db" {
   name = join("", [
     var.project_name,

--- a/infra/production/variables.tf
+++ b/infra/production/variables.tf
@@ -66,3 +66,8 @@ variable "azuread_admin_group_object_id" {
   type    = string
   default = ""
 }
+
+variable "newrelic_license_key" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
Azure VM Extensions allow installing Newrelic infrastructure agent. This change installs the NewRelic infra agent for raw-data backend VM.

I could not find any documentation about how to automate what is usually done in Azure web console. So I used Azure CLI (`az vm extension set`) to induce an error and guess what the parameters are to be supplied in the `settings` block. I believe it is `NR_LICENSE_KEY`. But I could be wrong.

Please send thoughts and prayers!