### PR TITLE
Add a storage account to resource group

### DIFF
--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -35,6 +35,16 @@ resource "azurerm_resource_group" "raw-data" {
   location = var.arm_location
 }
 
+resource "azurerm_storage_account" "raw-data" {
+  name                     = "rawdata"
+  resource_group_name      = azurerm_resource_group.raw-data.name
+  location                 = azurerm_resource_group.raw-data.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = local.required_tags
+}
+
 resource "azurerm_virtual_network" "raw-data" {
   name                = join("-", [var.project_name, var.deployment_environment])
   resource_group_name = azurerm_resource_group.raw-data.name


### PR DESCRIPTION
Add storage account (blob store) in order to shunt large database backup files to Azure from AWS.