### PR TITLE
Add systemd unit files for raw-data services

### DIFF
--- a/infra/systemd/raw-data-api.service
+++ b/infra/systemd/raw-data-api.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Raw Data API Service
+Documentation=https://github.com/hotosm/raw-data-api/blob/develop/README.md
+After=network.target syslog.target
+AssertFileNotEmpty=/opt/raw-data-api/API/sensitive.env
+
+[Service]
+Type=simple
+User=hotsysadmin
+WorkingDirectory=/opt/raw-data-api
+ExecStart=/opt/raw-data-api/API/venv/bin/uvicorn API.main:app --reload 
+EnvironmentFile=/opt/raw-data-api/API/sensitive.env
+ReadWritePaths=/opt/raw-data-api/API
+;
+; SECURITY OPTIONS
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=noaccess
+ProtectSystem=strict
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target
+

--- a/infra/systemd/raw-data-backend.service
+++ b/infra/systemd/raw-data-backend.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Raw Data Backend Service
+Documentation=https://github.com/hotosm/raw-data-api/blob/develop/backend/Readme.md
+After=network.target syslog.target
+AssertFileNotEmpty=/opt/raw-data-api/backend/PGCRED.env
+
+[Service]
+Type=simple
+User=hotsysadmin
+WorkingDirectory=/opt/raw-data-api/backend
+ExecStart=/opt/raw-data-api/backend/venv/bin/python raw_backend --replication --run_minutely
+Restart=on-failure
+EnvironmentFile=/opt/raw-data-api/backend/PGCRED.env
+ReadWritePaths=/opt/raw-data-api/backend
+;
+; SECURITY OPTIONS
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=noaccess
+ProtectSystem=strict
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/raw-data-worker.service
+++ b/infra/systemd/raw-data-worker.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Raw Data Celery Workers
+Documentation=https://github.com/hotosm/raw-data-api/blob/develop/README.md
+After=network.target syslog.target
+AssertFileNotEmpty=/opt/raw-data-api/API/sensitive.env
+
+[Service]
+Type=simple
+User=hotsysadmin
+WorkingDirectory=/opt/raw-data-api
+ExecStart=/opt/raw-data-api/API/venv/bin/celery --app API.api_worker worker --loglevel=INFO
+EnvironmentFile=/opt/raw-data/api/API/sensitive.env
+Restart=on-failure
+ReadWritePaths=/opt/raw-data-api/API
+;
+; SECURITY OPTIONS
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=noaccess
+ProtectSystem=strict
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Add systemd unit files for API, backend and worker services. Care has been taken to add security options without compromising program functions.

Unit files check for the existence of env files needed for the programs