### PR TITLE
Improve ansible scripts to cover more ground

### DIFF
--- a/infra/ansible/Readme.md
+++ b/infra/ansible/Readme.md
@@ -1,0 +1,29 @@
+# Ansible for configuration management
+
+## What is ansible and why use it?
+
+TBD
+
+## Building your server inventory
+
+TBD
+
+## Using OpenSSH client config aliases in place of FQDN in the inventory
+
+TBD 
+
+## Validating ansible playbooks
+
+```
+ansible-playbook --check -i inventory/raw-data -l prod setup.yml
+```
+
+## Running ansible playbooks
+
+```
+$ ansible-playbook -i inventory/raw-data -l prod setup.yml
+```
+
+## Templating and variables
+
+TBD

--- a/infra/ansible/inventory/example-inventory
+++ b/infra/ansible/inventory/example-inventory
@@ -11,3 +11,12 @@ stage
 [raw-data:vars]
 ansible_ssh_user=unixadmin
 become=yes
+PGHOST="example.postgres.database.azure.com"
+PGPORT="5432"
+PGPASSWORD="myGreatSecret123"
+PGDATABASE="mydb"
+PGUSER="orgdbadmin"
+REDIS_HOST="example.redis.cache.windows.net"
+REDIS_PORT="6380"
+LINUX_PROCESS_USER="rawdata"
+LINUX_PROCESS_GROUP="rawdata"

--- a/infra/ansible/setup.yml
+++ b/infra/ansible/setup.yml
@@ -2,6 +2,12 @@
 - name: Setup Instance Packages
   hosts: all
   become: yes
+
+  vars:
+    app:
+      base_uri: 'raw-data.example.net'
+      bind_port: '8000'
+
   tasks:
     - name: Update apt cache
       ansible.builtin.apt:
@@ -42,6 +48,30 @@
       ansible.builtin.apt:
         deb: https://github.com/caddyserver/caddy/releases/download/v2.6.4/caddy_2.6.4_linux_amd64.deb
 
+    - name: Create caddy config directory
+      ansible.builtin.file:
+        path: /etc/caddy
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Generate caddy forwarding proxy configuration
+      ansible.builtin.template:
+        src: /opt/raw-data-api/Caddyfile.j2
+        dest: /etc/caddy/Caddyfile
+        owner: root
+        group: root
+        mode: '0444'
+
+    - name: Install caddy systemd file
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/caddyserver/dist/master/init/caddy.service
+        dest: /etc/systemd/system/caddy.service
+        owner: root
+        group: root
+        mode: '0644'
+
     - name: Mark project directory safe in git
       ansible.builtin.command: git config --global --add safe.directory /opt/raw-data-api
 
@@ -52,11 +82,19 @@
 
     - name: Set directory ownership and permissions
       ansible.builtin.file:
-        owner: hotsysadmin
+        owner: "{{ LINUX_PROCESS_USER }}"
+        group: "{{ LINUX_PROCESS_GROUP }}"
         path: /opt/raw-data-api
         recurse: true
-        group: hotsysadmin
         mode: u+rw,g-wx,o-rwx
+
+    - name: Generate env file containing PostgreSQL credentials
+      ansible.builtin.template:
+        src: /opt/raw-data-api/infra/ansible/template/database.env.j2
+        dest: /opt/raw-data-api/API/PGCRED.env
+        owner: "{{ LINUX_PROCESS_USER }}"
+        group: "{{ LINUX_PROCESS_GROUP }}"
+        mode: '0444'
 
     - name: Upgrade Pip and setup Virtualenv
       ansible.builtin.pip:
@@ -64,4 +102,65 @@
         virtualenv: /opt/raw-data-api/.virtualenv
         virtualenv_site_packages: yes
 
+    - name: Copy raw-data service files
+      ansible.builtin.copy:
+        src: "/opt/raw-data-api/infra/systemd/{{ item }}"
+        dest: "/etc/systemd/system/{{ item }}"
+        owner: root
+        group: root
+        mode: '0644'
+      loop:
+        - raw-data-backend.service
+        - raw-data-api.service
+        - raw-data-worker.service
+
+    - name: Check redis is reachable
+      ansible.builtin.wait_for:
+        host: "{{ REDIS_HOST }}"
+        port: "{{ REDIS_PORT }}"
+        timeout: 5
+
+    - name: Check if PostgreSQL is reachable
+      ansible.builtin.wait_for:
+        host: "{{ PGHOST }}"
+        port: "{{ PGPORT }}"
+        timeout: 5
+
+    - name: Check if PostgreSQL is connectible
+      community.postgresql.postgresql_ping:
+        login_db: "{{ PGDATABASE }}"
+        login_host: "{{ PGHOST }}"
+        login_user: "{{ PGUSER }}"
+        login_password: "{{ PGPASSWORD }}"
+        ssl_mode: require
+      register: pgping_result
+
+    - name: Enable raw-data backend service and ensure it is running
+      ansible.builtin.systemd:
+        name: raw-data-backend.service
+        enabled: true
+        state: started
+      when: pgping_result.is_available == true
+
+    - name: Ensure raw-data API and worker services are enabled and running
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        enabled: true
+        state: started
+      loop:
+        - raw-data-api.service
+        - raw-data-worker.service
+
+    - name: Check if API serivce is reachable locally
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 8000
+        timeout: 5
+
+    - name: Enable raw-data worker service and ensure it is running
+      ansible.builtin.systemd:
+        name: caddy.service
+        enabled: true
+        state: started
 ...
+

--- a/infra/ansible/templates/Caddyfile.j2
+++ b/infra/ansible/templates/Caddyfile.j2
@@ -1,0 +1,3 @@
+{{ app.base_uri }} {
+  reverse_proxy 127.0.0.1:{{ app.bind_port }}
+}

--- a/infra/ansible/templates/database.env.j2
+++ b/infra/ansible/templates/database.env.j2
@@ -1,0 +1,8 @@
+# Please quote passwords to accommodate for shell-unfriendly characters
+# Ensure that new database names comply with recommended PGSQL / SQL convention for allowed characters
+PGPASSWORD={{ PGPASSWORD }}
+PGUSER={{ PGUSER }}
+PGHOST={{ PGHOST }}
+PGPORT={{ PGPORT }}
+PGDATABASE={{ PGDATABASE }}
+


### PR DESCRIPTION
Use ansible to setup systemd services, reverse proxy, and dependencies.

- Setup systemd service files for raw-data API, Worker and Backend
- Add associated env files for systemd along with basic sanity checks
- Setup Caddy server as a reverse proxy along with appropriate configuration.
- Parameterise variables
- Consolidate multiple similar resources using loops