### PR TITLE
Remove systemd assertions

### DIFF
--- a/infra/ansible/setup.yml
+++ b/infra/ansible/setup.yml
@@ -83,7 +83,7 @@
     - name: Generate env file containing PostgreSQL credentials
       ansible.builtin.template:
         src: "{{ playbook_dir }}/templates/database.env.j2"
-        dest: /opt/raw-data-api/API/database.env
+        dest: /opt/raw-data-api/backend/database.env
         owner: "{{ LINUX_PROCESS_USER }}"
         group: "{{ LINUX_PROCESS_GROUP }}"
         mode: '0444'
@@ -127,6 +127,10 @@
         login_password: "{{ PGPASSWORD }}"
         ssl_mode: require
       register: pgping_result
+
+    - name: Force systemd to reread configs just-in-case
+      ansible.builtin.systemd:
+        daemon_reload: true
 
     - name: Enable raw-data backend service and ensure it is running
       ansible.builtin.systemd:

--- a/infra/systemd/raw-data-worker.service
+++ b/infra/systemd/raw-data-worker.service
@@ -2,14 +2,12 @@
 Description=Raw Data Celery Workers
 Documentation=https://github.com/hotosm/raw-data-api/blob/develop/README.md
 After=network.target syslog.target
-AssertFileNotEmpty=/opt/raw-data-api/API/sensitive.env
 
 [Service]
 Type=simple
 User=hotsysadmin
 WorkingDirectory=/opt/raw-data-api
 ExecStart=/opt/raw-data-api/API/venv/bin/celery --app API.api_worker worker --loglevel=INFO
-EnvironmentFile=/opt/raw-data/api/API/sensitive.env
 Restart=on-failure
 ReadWritePaths=/opt/raw-data-api/API
 ;


### PR DESCRIPTION
- Worker and API systemd files do not require EnvironmentFile option. So removed it.
- Added a systemd daemon_reload action in Ansible to reread config after changes to systemd unit files