### PR TITLE
Fix invalid backend VM SKU for Gen2 Linux images

### DIFF
--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -355,7 +355,7 @@ resource "azurerm_postgresql_flexible_server_configuration" "raw-data-password-e
 
 resource "azurerm_postgresql_flexible_server_configuration" "raw-data-azure-password-encryption" {
   server_id = azurerm_postgresql_flexible_server.raw-data.id
-  name      = " azure.accepted_password_auth_method"
+  name      = "azure.accepted_password_auth_method"
   value     = "md5,scram-sha-256"
 }
 

--- a/infra/production/variables.tf
+++ b/infra/production/variables.tf
@@ -52,7 +52,7 @@ variable "server_skus" {
   type = map(any)
   default = {
     database = "GP_Standard_D2ds_v4"
-    backend  = "Standard_F2"
+    backend  = "Standard_D2ls_v5"
   }
 }
 


### PR DESCRIPTION
Gen2 Azure VM images have restrictions with the type of VM SKU they can be run on. Fixed it with a better default SKU - `Standard_D2ls_v5`

Fixed extraneous space in parameter key for Azure Flexible PostgreSQL server.