### PR TITLE
Add container instances for API

### DIFF
--- a/infra/production/container.tf
+++ b/infra/production/container.tf
@@ -1,0 +1,26 @@
+resource "azurerm_container_group" "app" {
+  name                = join("-", [var.project_name, var.deployment_environment])
+  resource_group_name = azurerm_resource_group.raw-data.name
+  location            = azurerm_resource_group.raw-data.location
+
+  ip_address_type = "Private"
+  subnet_ids      = [azurerm_subnet.raw-data-containers.id]
+  os_type         = "Linux"
+
+  container {
+    name   = "api"
+    image  = lookup(var.container_images, "api")
+    cpu    = "0.5"
+    memory = "1.5"
+
+    ports {
+      port     = 8000
+      protocol = "TCP"
+    }
+
+    environment_variables = var.container_envvar
+  }
+
+  tags = {
+  }
+}

--- a/infra/production/main.tf
+++ b/infra/production/main.tf
@@ -71,7 +71,21 @@ resource "azurerm_subnet" "raw-data-containers" {
   virtual_network_name = azurerm_virtual_network.raw-data.name
   address_prefixes     = [cidrsubnet(azurerm_virtual_network.raw-data.address_space[0], 5, 1)]
 
-  service_endpoints = ["Microsoft.KeyVault"]
+  delegation {
+    name = "containers"
+
+    service_delegation {
+      name = "Microsoft.ContainerInstance/containerGroups"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action"
+      ]
+    }
+  }
+
+  service_endpoints = [
+    "Microsoft.ContainerRegistry",
+    "Microsoft.KeyVault"
+  ]
 }
 
 resource "azurerm_subnet" "raw-data-db" {

--- a/infra/production/variables.tf
+++ b/infra/production/variables.tf
@@ -72,3 +72,18 @@ variable "newrelic_license_key" {
   type    = string
   default = ""
 }
+
+variable "container_images" {
+  description = "Remote container image URI to pull from"
+  type        = map(string)
+
+  default = {
+    api    = "quay.io/hotosm/raw-data-api:latest"
+    worker = "quay.io/hotosm/raw-data-api:latest"
+  }
+}
+
+variable "container_envvar" {
+  description = "Environment Variables to pass to the container"
+  type        = map(string)
+}


### PR DESCRIPTION
- Add container instances for API
- Modify existing subnet to delegate to ContainerInstances
- Add KeyVault and ContainerRegistry endpoint access to subnet
- Add necessary variables for the container group