### PR TITLE
Remove optional extra value from credentials JSON

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -390,8 +390,9 @@ def get_db_connection_params() -> dict:
         connection_params = json.loads(db_credentials)
 
         connection_params["user"] = connection_params["username"]
-        for k in ("dbinstanceidentifier", "engine", "username"):
-            connection_params.pop(k, None)
+        for k in ("dbinstanceidentifier", "dbClusterIdentifier", "engine", "username"):
+            if k in connection_params:
+                connection_params.pop(k, None)
 
     if None in connection_params.values():
         raise ValueError(


### PR DESCRIPTION
Secrets manager entry holding DB credentials could have dbInstanceIdentifier or dbCluesterIdentifier depending on the type of database in use. This change removes both keys.

Also checks if key is present in dict before attempting to delete it.

