### PR TITLE
Feature : Admin to bypass area threshold in stats endpoint 

### DIFF
--- a/API/stats.py
+++ b/API/stats.py
@@ -1,14 +1,15 @@
 import json
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, Request, Depends, HTTPException
 from fastapi_versioning import version
-
+from area import area
 from src.app import PolygonStats
 from src.config import LIMITER as limiter
 from src.config import POLYGON_STATISTICS_API_RATE_LIMIT
 from src.validation.models import StatsRequestParams
 
 router = APIRouter(prefix="/stats", tags=["Stats"])
+from .auth import AuthUser, UserRole, get_optional_user
 
 
 @router.post("/polygon/")
@@ -45,6 +46,7 @@ async def get_polygon_stats(
             },
         },
     ),
+    user: AuthUser = Depends(get_optional_user),
 ):
     """Get statistics for the specified polygon.
 
@@ -55,6 +57,19 @@ async def get_polygon_stats(
     Returns:
         dict: A dictionary containing statistics for the specified polygon.
     """
+    if not (user.role is UserRole.STAFF.value or user.role is UserRole.ADMIN.value):
+        area_m2 = area(json.loads(params.geometry.model_dump_json()))
+        area_km2 = area_m2 * 1e-6
+        limit = 10000
+        if area_km2 > limit:
+            raise HTTPException(
+                status_code=400,
+                detail=[
+                    {
+                        "msg": f"""Polygon Area {int(area_km2)} Sq.KM is higher than Threshold : {limit} Sq.KM"""
+                    }
+                ],
+            )
     feature = None
     if params.geometry:
         feature = {

--- a/API/stats.py
+++ b/API/stats.py
@@ -1,8 +1,12 @@
+# Standard library imports
 import json
 
-from fastapi import APIRouter, Body, Request, Depends, HTTPException
-from fastapi_versioning import version
+# Third party imports
 from area import area
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from fastapi_versioning import version
+
+# Reader imports
 from src.app import PolygonStats
 from src.config import LIMITER as limiter
 from src.config import POLYGON_STATISTICS_API_RATE_LIMIT
@@ -58,18 +62,19 @@ async def get_polygon_stats(
         dict: A dictionary containing statistics for the specified polygon.
     """
     if not (user.role is UserRole.STAFF.value or user.role is UserRole.ADMIN.value):
-        area_m2 = area(json.loads(params.geometry.model_dump_json()))
-        area_km2 = area_m2 * 1e-6
-        limit = 10000
-        if area_km2 > limit:
-            raise HTTPException(
-                status_code=400,
-                detail=[
-                    {
-                        "msg": f"""Polygon Area {int(area_km2)} Sq.KM is higher than Threshold : {limit} Sq.KM"""
-                    }
-                ],
-            )
+        if params.geometry:
+            area_m2 = area(json.loads(params.geometry.model_dump_json()))
+            area_km2 = area_m2 * 1e-6
+            limit = 10000
+            if area_km2 > limit:
+                raise HTTPException(
+                    status_code=400,
+                    detail=[
+                        {
+                            "msg": f"""Polygon Area {int(area_km2)} Sq.KM is higher than Threshold : {limit} Sq.KM"""
+                        }
+                    ],
+                )
     feature = None
     if params.geometry:
         feature = {

--- a/src/app.py
+++ b/src/app.py
@@ -21,8 +21,8 @@
 import concurrent.futures
 import json
 import os
-import random
 import pathlib
+import random
 import re
 import shutil
 import subprocess
@@ -1062,13 +1062,13 @@ class PolygonStats:
             try:
                 query = generate_polygon_stats_graphql_query(self.INPUT_GEOM)
                 payload = {"query": query}
-                response = requests.post(self.API_URL, json=payload, timeout=30)
+                response = requests.post(self.API_URL, json=payload, timeout=20)
                 response.raise_for_status() 
                 return response.json()
             except Exception as e:
                 print(f"Request failed: {e}")
                 retries += 1
-                delay = min(delay * 2, MAX_DELAY)  # Exponential backoff
+                delay = min(delay * 0.5, MAX_DELAY)  # Exponential backoff
                 jitter = random.uniform(0, 1)  #  jitter to avoid simultaneous retries
                 sleep_time = delay * (1 + jitter)
                 print(f"Retrying in {sleep_time} seconds...")

--- a/src/app.py
+++ b/src/app.py
@@ -1053,7 +1053,7 @@ class PolygonStats:
         """
         MAX_RETRIES = 2  # Maximum number of retries
         INITIAL_DELAY = 1  # Initial delay in seconds
-        MAX_DELAY = 8  
+        MAX_DELAY = 8
 
         retries = 0
         delay = INITIAL_DELAY
@@ -1063,7 +1063,7 @@ class PolygonStats:
                 query = generate_polygon_stats_graphql_query(self.INPUT_GEOM)
                 payload = {"query": query}
                 response = requests.post(self.API_URL, json=payload, timeout=20)
-                response.raise_for_status() 
+                response.raise_for_status()
                 return response.json()
             except Exception as e:
                 print(f"Request failed: {e}")
@@ -1077,7 +1077,7 @@ class PolygonStats:
         # If all retries failed, return None
         print("Maximum retries exceeded. Unable to fetch data.")
         return None
-    
+
     def get_summary_stats(self):
         """
         Generates summary statistics for buildings and roads.

--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -328,18 +328,7 @@ class StatsRequestParams(BaseModel, GeometryValidatorMixin):
             raise ValueError("Either geometry or iso3 should be supplied.")
         return value
 
-    @validator("geometry", pre=True, always=True)
-    def validate_geometry_area(cls, value):
-        """Validate that the geometry area does not exceed threshold."""
-        if value is not None:
-            geometry_json = value
-            area_m2 = area(geometry_json)
-            max_area = 10000
-            if area_m2 * 1e-6 > max_area:
-                raise ValueError(
-                    f"The area {area_m2 * 1e-6} sqkm of the geometry should not exceed {max_area} square km."
-                )
-        return value
+
 
 
 ### HDX BLock

--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -301,22 +301,22 @@ class StatsRequestParams(BaseModel, GeometryValidatorMixin):
         max_length=3,
         example="NPL",
     )
-    geometry: Optional[
-        Union[Polygon, MultiPolygon, Feature, FeatureCollection]
-    ] = Field(
-        default=None,
-        example={
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [83.96919250488281, 28.194446860487773],
-                    [83.99751663208006, 28.194446860487773],
-                    [83.99751663208006, 28.214869548073377],
-                    [83.96919250488281, 28.214869548073377],
-                    [83.96919250488281, 28.194446860487773],
-                ]
-            ],
-        },
+    geometry: Optional[Union[Polygon, MultiPolygon, Feature, FeatureCollection]] = (
+        Field(
+            default=None,
+            example={
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [83.96919250488281, 28.194446860487773],
+                        [83.99751663208006, 28.194446860487773],
+                        [83.99751663208006, 28.214869548073377],
+                        [83.96919250488281, 28.214869548073377],
+                        [83.96919250488281, 28.194446860487773],
+                    ]
+                ],
+            },
+        )
     )
 
     @validator("geometry", pre=True, always=True)
@@ -327,8 +327,6 @@ class StatsRequestParams(BaseModel, GeometryValidatorMixin):
         if value is None and values.get("iso3") is None:
             raise ValueError("Either geometry or iso3 should be supplied.")
         return value
-
-
 
 
 ### HDX BLock
@@ -615,22 +613,22 @@ class DynamicCategoriesModel(BaseModel, GeometryValidatorMixin):
             }
         ],
     )
-    geometry: Optional[
-        Union[Polygon, MultiPolygon, Feature, FeatureCollection]
-    ] = Field(
-        default=None,
-        example={
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [83.96919250488281, 28.194446860487773],
-                    [83.99751663208006, 28.194446860487773],
-                    [83.99751663208006, 28.214869548073377],
-                    [83.96919250488281, 28.214869548073377],
-                    [83.96919250488281, 28.194446860487773],
-                ]
-            ],
-        },
+    geometry: Optional[Union[Polygon, MultiPolygon, Feature, FeatureCollection]] = (
+        Field(
+            default=None,
+            example={
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [83.96919250488281, 28.194446860487773],
+                        [83.99751663208006, 28.194446860487773],
+                        [83.99751663208006, 28.214869548073377],
+                        [83.96919250488281, 28.214869548073377],
+                        [83.96919250488281, 28.194446860487773],
+                    ]
+                ],
+            },
+        )
     )
 
     @validator("geometry", pre=True, always=True)


### PR DESCRIPTION
## What does this PR do ? 
- Let admin or staff bypass the area threshold limit for the polygon stats 

## How to test ? 
- Run endpoint with your access token and without , if you are admin or staff you should be able to bypass the limit 

## Consideration : 
- Introduced exponential backoff on API timeout or failure to retry the stats endpoint ( Kontour ) 

