### PR TITLE
Check if key is set before trying to get value

### DIFF
--- a/backend/raw_backend
+++ b/backend/raw_backend
@@ -159,7 +159,8 @@ def download_file(download_dir, source_path):
     target_path = os.path.join(download_dir, filename)
     if not os.path.exists(target_path):
         print(f"\nStarting download for: {target_path}")
-        if os.environ["OSM_USERNAME"] and os.environ["OSM_PASSWORD"]:
+        if "OSM_USERNAME" in os.environ and os.environ["OSM_USERNAME"] and \
+            "OSM_PASSWORD" in os.environ and os.environ["OSM_PASSWORD"]:
             cookies = verify_me_osm(
                 os.environ["OSM_USERNAME"], os.environ["OSM_PASSWORD"]
             )


### PR DESCRIPTION
## What type of PR is this? 

- [X] 🐛 Bug Fix

## What does this PR do ?

If `OSM_PASSWORD` and `OSM_USERNAME` are not set as environment variables, the `raw_backend --insert --replication ...` command is failing because a piece of code that's trying to get an unset variable from the os.environ object.

This PR solves that issue.