### PR TITLE
+ GeoJSON stats for exports

### DIFF
--- a/API/api_worker.py
+++ b/API/api_worker.py
@@ -75,7 +75,12 @@ def create_readme_content(default_readme, polygon_stats):
 
 
 def zip_binding(
-    working_dir, exportname_parts, geom_dump, polygon_stats, geojson_stats, default_readme
+    working_dir,
+    exportname_parts,
+    geom_dump,
+    polygon_stats,
+    geojson_stats,
+    default_readme,
 ):
     logging.debug("Zip Binding Started!")
     upload_file_path = os.path.join(
@@ -167,6 +172,7 @@ class BaseclassTask(celery.Task):
         clean_dir = os.path.join(EXPORT_PATH, task_id)
         if os.path.exists(clean_dir):
             shutil.rmtree(clean_dir)
+
 
 @celery.task(
     bind=True,

--- a/API/api_worker.py
+++ b/API/api_worker.py
@@ -15,7 +15,7 @@ import zipfly
 from celery import Celery
 
 # Reader imports
-from src.app import CustomExport, PolygonStats, RawData, S3FileTransfer
+from src.app import CustomExport, PolygonStats, GeoJSONStats, RawData, S3FileTransfer
 from src.config import ALLOW_BIND_ZIP_FILTER
 from src.config import CELERY_BROKER_URL as celery_broker_uri
 from src.config import CELERY_RESULT_BACKEND as celery_backend
@@ -75,7 +75,7 @@ def create_readme_content(default_readme, polygon_stats):
 
 
 def zip_binding(
-    working_dir, exportname_parts, geom_dump, polygon_stats, default_readme
+    working_dir, exportname_parts, geom_dump, polygon_stats, geojson_stats, default_readme
 ):
     logging.debug("Zip Binding Started!")
     upload_file_path = os.path.join(
@@ -87,6 +87,9 @@ def zip_binding(
             default_readme=default_readme, polygon_stats=polygon_stats
         ),
     }
+
+    if geojson_stats:
+        additional_files["stats.json"] = geojson_stats
 
     for name, content in additional_files.items():
         temp_path = os.path.join(working_dir, name)
@@ -165,7 +168,6 @@ class BaseclassTask(celery.Task):
         if os.path.exists(clean_dir):
             shutil.rmtree(clean_dir)
 
-
 @celery.task(
     bind=True,
     name="process_raw_data",
@@ -209,11 +211,22 @@ def process_raw_data(self, params, user=None):
             file_parts,
         )
 
-        geom_area, geom_dump, working_dir = RawData(
-            params, str(self.request.id)
-        ).extract_current_data(file_parts)
-        inside_file_size = 0
         polygon_stats = None
+        geojson_stats = None
+
+        if "include_stats" in params.dict():
+            if params.include_stats:
+                geoJSONStats = GeoJSONStats(params.filters)
+                geom_area, geom_dump, working_dir = RawData(
+                    params, str(self.request.id)
+                ).extract_current_data(file_parts, geoJSONStats.raw_data_line_stats)
+                geojson_stats = geoJSONStats.json()
+            else:
+                geom_area, geom_dump, working_dir = RawData(
+                    params, str(self.request.id)
+                ).extract_current_data(file_parts)
+
+        inside_file_size = 0
         if "include_stats" in params.dict():
             if params.include_stats:
                 feature = {
@@ -222,12 +235,14 @@ def process_raw_data(self, params, user=None):
                     "properties": {},
                 }
                 polygon_stats = PolygonStats(feature).get_summary_stats()
+
         if bind_zip:
             upload_file_path, inside_file_size = zip_binding(
                 working_dir=working_dir,
                 exportname_parts=exportname_parts,
                 geom_dump=geom_dump,
                 polygon_stats=polygon_stats,
+                geojson_stats=geojson_stats,
                 default_readme=DEFAULT_README_TEXT,
             )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,7 @@ psutil==5.9.8
 
 ## logging 
 tqdm==4.66.2
+
+# stats for geojson data
+geojson-stats @ git+https://github.com/emi420/geojson-stats@v0.0.1-alpha
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,5 +56,5 @@ psutil==5.9.8
 tqdm==4.66.2
 
 # stats for geojson data
-geojson-stats @ git+https://github.com/emi420/geojson-stats@v0.0.1-alpha
+geojson-stats==0.1.0
 

--- a/src/app.py
+++ b/src/app.py
@@ -2306,10 +2306,9 @@ class GeoJSONStats(Stats):
             if tags.line.join_and and tag in tags.line.join_and:
                 return True
 
-    """
-    Process a GeoJSON line (for getting stats) and return that line
-    """
-
     def raw_data_line_stats(self, line: str):
+        """
+        Process a GeoJSON line (for getting stats) and return that line
+        """
         self.process_file_line(line)
         return line

--- a/src/app.py
+++ b/src/app.py
@@ -641,7 +641,7 @@ class RawData:
         os.remove(query_path)
 
     @staticmethod
-    def query2geojson(con, extraction_query, dump_temp_file_path, plugin_fn = None):
+    def query2geojson(con, extraction_query, dump_temp_file_path, plugin_fn=None):
         """Function written from scratch without being dependent on any library, Provides better performance for geojson binding"""
         # creating geojson file
         pre_geojson = """{"type": "FeatureCollection","features": ["""
@@ -714,7 +714,7 @@ class RawData:
             country_export,
         )
 
-    def extract_current_data(self, exportname, plugin_fn = None):
+    def extract_current_data(self, exportname, plugin_fn=None):
         """Responsible for Extracting rawdata current snapshot, Initially it creates a geojson file , Generates query , run it with 1000 chunk size and writes it directly to the geojson file and closes the file after dump
         Args:
             exportname: takes filename as argument to create geojson file passed from routers
@@ -780,7 +780,7 @@ class RawData:
                         country_export=country_export,
                     ),
                     dump_temp_file_path,
-                    plugin_fn
+                    plugin_fn,
                 )  # uses own conversion class
             if output_type == RawDataOutputType.SHAPEFILE.value:
                 (
@@ -2260,6 +2260,7 @@ class DownloadMetrics:
         self.d_b.close_conn()
         return [dict(item) for item in result]
 
+
 class GeoJSONStats(Stats):
     """Used for collecting stats while processing GeoJSON files line by line"""
 
@@ -2304,6 +2305,10 @@ class GeoJSONStats(Stats):
                 return True
             if tags.line.join_and and tag in tags.line.join_and:
                 return True
+
+    """
+    Process a GeoJSON line (for getting stats) and return that line
+    """
 
     def raw_data_line_stats(self, line: str):
         self.process_file_line(line)

--- a/src/app.py
+++ b/src/app.py
@@ -47,6 +47,7 @@ from psycopg2 import OperationalError, connect, sql
 from psycopg2.extras import DictCursor
 from slugify import slugify
 from tqdm import tqdm
+from geojson_stats.stats import Stats
 
 # Reader imports
 from src.config import (
@@ -640,7 +641,7 @@ class RawData:
         os.remove(query_path)
 
     @staticmethod
-    def query2geojson(con, extraction_query, dump_temp_file_path):
+    def query2geojson(con, extraction_query, dump_temp_file_path, plugin_fn = None):
         """Function written from scratch without being dependent on any library, Provides better performance for geojson binding"""
         # creating geojson file
         pre_geojson = """{"type": "FeatureCollection","features": ["""
@@ -660,10 +661,12 @@ class RawData:
                 for row in cursor:
                     if first:
                         first = False
-                        f.write(row[0])
                     else:
                         f.write(",")
-                        f.write(row[0])
+                    if plugin_fn:
+                        f.write(plugin_fn(row[0]))
+                    else:
+                        f.write((row[0]))
                 cursor.close()  # closing connection to avoid memory issues
                 # close the writing geojson with last part
             f.write(post_geojson)
@@ -711,7 +714,7 @@ class RawData:
             country_export,
         )
 
-    def extract_current_data(self, exportname):
+    def extract_current_data(self, exportname, plugin_fn = None):
         """Responsible for Extracting rawdata current snapshot, Initially it creates a geojson file , Generates query , run it with 1000 chunk size and writes it directly to the geojson file and closes the file after dump
         Args:
             exportname: takes filename as argument to create geojson file passed from routers
@@ -777,6 +780,7 @@ class RawData:
                         country_export=country_export,
                     ),
                     dump_temp_file_path,
+                    plugin_fn
                 )  # uses own conversion class
             if output_type == RawDataOutputType.SHAPEFILE.value:
                 (
@@ -2255,3 +2259,48 @@ class DownloadMetrics:
         result = self.cur.fetchall()
         self.d_b.close_conn()
         return [dict(item) for item in result]
+
+class GeoJSONStats(Stats):
+    """Used for collecting stats while processing GeoJSON files line by line"""
+
+    def __init__(self, filters, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.config.clean = True
+        self.config.properties_prop = "properties.tags"
+
+        if filters and filters.tags:
+            config_area = ["building"]
+            config_length = ["highway", "waterway"]
+
+            for tag in config_area:
+                if self.check_filter(filters.tags, tag):
+                    self.config.keys.append(tag)
+                    self.config.value_keys.append(tag)
+                    self.config.area = True
+            for tag in config_length:
+                if self.check_filter(filters.tags, tag):
+                    self.config.keys.append(tag)
+                    self.config.value_keys.append(tag)
+                    self.config.length = True
+
+    def check_filter(self, tags, tag):
+        if tags.all_geometry:
+            if tags.all_geometry.join_or and tag in tags.all_geometry.join_or:
+                return True
+            if tags.all_geometry.join_and and tag in tags.all_geometry.join_and:
+                return True
+        if tags.polygon:
+            if tags.polygon.join_or and tag in tags.polygon.join_or:
+                return True
+            if tags.polygon.join_and and tag in tags.polygon.join_and:
+                return True
+        if tags.line:
+            if tags.line.join_or and tag in tags.line.join_or:
+                return True
+            if tags.line.join_and and tag in tags.line.join_and:
+                return True
+
+    def raw_data_line_stats(self, line: str):
+        self.process_file_line(line)
+        return line

--- a/src/app.py
+++ b/src/app.py
@@ -2285,6 +2285,10 @@ class GeoJSONStats(Stats):
                     self.config.length = True
 
     def check_filter(self, tags, tag):
+        """
+        Check if a tag is present in tag filters
+        """
+
         if tags.all_geometry:
             if tags.all_geometry.join_or and tag in tags.all_geometry.join_or:
                 return True

--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -303,22 +303,22 @@ class StatsRequestParams(BaseModel, GeometryValidatorMixin):
         max_length=3,
         example="NPL",
     )
-    geometry: Optional[Union[Polygon, MultiPolygon, Feature, FeatureCollection]] = (
-        Field(
-            default=None,
-            example={
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [83.96919250488281, 28.194446860487773],
-                        [83.99751663208006, 28.194446860487773],
-                        [83.99751663208006, 28.214869548073377],
-                        [83.96919250488281, 28.214869548073377],
-                        [83.96919250488281, 28.194446860487773],
-                    ]
-                ],
-            },
-        )
+    geometry: Optional[
+        Union[Polygon, MultiPolygon, Feature, FeatureCollection]
+    ] = Field(
+        default=None,
+        example={
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [83.96919250488281, 28.194446860487773],
+                    [83.99751663208006, 28.194446860487773],
+                    [83.99751663208006, 28.214869548073377],
+                    [83.96919250488281, 28.214869548073377],
+                    [83.96919250488281, 28.194446860487773],
+                ]
+            ],
+        },
     )
 
     @validator("geometry", pre=True, always=True)
@@ -624,22 +624,22 @@ class DynamicCategoriesModel(CategoriesBase, GeometryValidatorMixin):
         max_length=3,
         example="USA",
     )
-    geometry: Optional[Union[Polygon, MultiPolygon, Feature, FeatureCollection]] = (
-        Field(
-            default=None,
-            example={
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [83.96919250488281, 28.194446860487773],
-                        [83.99751663208006, 28.194446860487773],
-                        [83.99751663208006, 28.214869548073377],
-                        [83.96919250488281, 28.214869548073377],
-                        [83.96919250488281, 28.194446860487773],
-                    ]
-                ],
-            },
-        )
+    geometry: Optional[
+        Union[Polygon, MultiPolygon, Feature, FeatureCollection]
+    ] = Field(
+        default=None,
+        example={
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [83.96919250488281, 28.194446860487773],
+                    [83.99751663208006, 28.194446860487773],
+                    [83.99751663208006, 28.214869548073377],
+                    [83.96919250488281, 28.214869548073377],
+                    [83.96919250488281, 28.194446860487773],
+                ]
+            ],
+        },
     )
 
     @validator("geometry", pre=True, always=True)

--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -303,22 +303,22 @@ class StatsRequestParams(BaseModel, GeometryValidatorMixin):
         max_length=3,
         example="NPL",
     )
-    geometry: Optional[
-        Union[Polygon, MultiPolygon, Feature, FeatureCollection]
-    ] = Field(
-        default=None,
-        example={
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [83.96919250488281, 28.194446860487773],
-                    [83.99751663208006, 28.194446860487773],
-                    [83.99751663208006, 28.214869548073377],
-                    [83.96919250488281, 28.214869548073377],
-                    [83.96919250488281, 28.194446860487773],
-                ]
-            ],
-        },
+    geometry: Optional[Union[Polygon, MultiPolygon, Feature, FeatureCollection]] = (
+        Field(
+            default=None,
+            example={
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [83.96919250488281, 28.194446860487773],
+                        [83.99751663208006, 28.194446860487773],
+                        [83.99751663208006, 28.214869548073377],
+                        [83.96919250488281, 28.214869548073377],
+                        [83.96919250488281, 28.194446860487773],
+                    ]
+                ],
+            },
+        )
     )
 
     @validator("geometry", pre=True, always=True)
@@ -624,22 +624,22 @@ class DynamicCategoriesModel(CategoriesBase, GeometryValidatorMixin):
         max_length=3,
         example="USA",
     )
-    geometry: Optional[
-        Union[Polygon, MultiPolygon, Feature, FeatureCollection]
-    ] = Field(
-        default=None,
-        example={
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [83.96919250488281, 28.194446860487773],
-                    [83.99751663208006, 28.194446860487773],
-                    [83.99751663208006, 28.214869548073377],
-                    [83.96919250488281, 28.214869548073377],
-                    [83.96919250488281, 28.194446860487773],
-                ]
-            ],
-        },
+    geometry: Optional[Union[Polygon, MultiPolygon, Feature, FeatureCollection]] = (
+        Field(
+            default=None,
+            example={
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [83.96919250488281, 28.194446860487773],
+                        [83.99751663208006, 28.194446860487773],
+                        [83.99751663208006, 28.214869548073377],
+                        [83.96919250488281, 28.214869548073377],
+                        [83.96919250488281, 28.194446860487773],
+                    ]
+                ],
+            },
+        )
     )
 
     @validator("geometry", pre=True, always=True)


### PR DESCRIPTION
## What type of PR is this? 

- [x] 🍕 Feature

## What does this PR do ?

This PR adds a new file `stats.json` to the exported .zip when `"include_stats": true` is in the request.

For make this work, a new parameter `plugin_fn` was added to the `query2geojson` function.

This function will be executed over every line of the resulting GeoJSON and can be used later to perform other actions like adding transliterations for names.

## How to test ? 

Send a request with `"include_stats": true` like this one:

```
curl -X 'POST' \
  'http://localhost:8000/v1/snapshot/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "include_stats": true,
  "geometry": {
    "type": "Polygon",
    "coordinates": [[[83.98115146067687,28.211311261108108],[83.98115146067687,28.200566215460043],[83.99977233635042,28.200566215460043],[83.99977233635042,28.211311261108108],[83.98115146067687,28.211311261108108]]]
  },
  "filters": {
    "tags": {
      "line": {
        "join_or": {
          "building": ["yes"]
        }
      }
    }
  }
}'
```

The resulting .zip file will include a `stats.json` file with statistics for tags.

