### PR TITLE
HOTFIX : Old exports cleanup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -94,6 +94,7 @@ from src.query_builder.builder import (
     postgres2duckdb_query,
     raw_currentdata_extraction_query,
 )
+from src.utils import create_working_dir
 from src.validation.models import EXPORT_TYPE_MAPPING, RawDataOutputType
 
 from .post_processing.processor import PostProcessor
@@ -736,7 +737,7 @@ class RawData:
         working_dir = os.path.join(self.base_export_working_dir, exportname)
         if not os.path.exists(working_dir):
             # Create a exports directory because it does not exist
-            os.makedirs(working_dir)
+            create_working_dir(working_dir)
         # create file path with respect to of output type
 
         dump_temp_file_path = os.path.join(

--- a/src/config.py
+++ b/src/config.py
@@ -213,6 +213,14 @@ USE_CONNECTION_POOLING = get_bool_env_var(
     config.getboolean("API_CONFIG", "USE_CONNECTION_POOLING", fallback=False),
 )
 
+
+ENABLE_OLD_EXPORTS_CLEANUP = get_bool_env_var(
+    "ENABLE_OLD_EXPORTS_CLEANUP",
+    config.getboolean("API_CONFIG", "ENABLE_OLD_EXPORTS_CLEANUP", fallback=False),
+)
+
+OLD_EXPORTS_CLEANUP_DAYS = os.environ.get("OLD_EXPORTS_CLEANUP_DAYS") or config.get("API_CONFIG", "OLD_EXPORTS_CLEANUP_DAYS", fallback=4)
+
 # Queue
 
 DEFAULT_QUEUE_NAME = os.environ.get("DEFAULT_QUEUE_NAME") or config.get(

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,57 @@
+# Standard library imports
+import errno
+import logging
+import os
+import shutil
+import time
+
+# Reader imports
+from src.config import ENABLE_OLD_EXPORTS_CLEANUP, OLD_EXPORTS_CLEANUP_DAYS
+
+
+def cleanup_old_exports(base_export_dir, days):
+    """
+    Removes directories in the base export directory that are older than the specified number of days.
+    """
+    now = time.time()
+    cutoff_time = now - (days * 86400)  # days to seconds
+
+    for dirpath, dirnames, filenames in os.walk(base_export_dir):
+
+       # Remove old files
+        for filename in filenames:
+            file_full_path = os.path.join(dirpath, filename)
+            if os.path.isfile(file_full_path) and os.path.getmtime(file_full_path) < cutoff_time:
+                os.remove(file_full_path)
+                logging.info(f"Removed old export file: {file_full_path}")
+
+        # Remove old directories
+        for dirname in dirnames:
+            dir_full_path = os.path.join(dirpath, dirname)
+            if os.path.isdir(dir_full_path) and os.path.getmtime(dir_full_path) < cutoff_time:
+                shutil.rmtree(dir_full_path)
+                logging.info(f"Removed old export directory: {dir_full_path}")
+
+def create_working_dir(working_dir):
+    """
+    Creates a working directory for exports. If cleanup is enabled, it first removes old directories.
+    """
+    base_export_working_dir = os.path.dirname(os.path.dirname(os.path.abspath(working_dir)))  # Get the grandparent directory , because exportdir/uid/export
+    # Check if cleanup is enabled
+    cleanup_enabled = ENABLE_OLD_EXPORTS_CLEANUP
+    cleanup_days = OLD_EXPORTS_CLEANUP_DAYS
+
+    if cleanup_enabled:
+        cleanup_old_exports(base_export_working_dir, cleanup_days)
+
+    if not os.path.exists(working_dir):
+        try:
+            os.makedirs(working_dir)
+        except OSError as e:
+            if e.errno == errno.ENOSPC:  # No space left on device
+                logging.warning("No space left on device, attempting to cleanup old exports and retry...")
+                cleanup_old_exports(base_export_working_dir, cleanup_days)
+                os.makedirs(working_dir)
+            else:
+                raise e
+    return working_dir


### PR DESCRIPTION
## What does this PR do ? 
- Cleans up the old exports in the working dir if there are any based on the env variable , if there is no space left API is forced to make cleanup ! 

## Consideration 
Don't get panicked if API is cleaning up the exports forcefully as long as you don't set the cleanup export days to 1 ! It is safe to delete the old exports greater than 4 days ! 