### PR TITLE
fix: migrate GeometryValidatorMixin to Pydantic V2 field_validator

### DIFF
--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Union
 # Third party imports
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
 from pydantic import BaseModel as PydanticModel
-from pydantic import Field, validator
+from pydantic import Field, field_validator, validator
 
 # Reader imports
 from src.config import (
@@ -120,7 +120,8 @@ class Filters(BaseModel):
 
 
 class GeometryValidatorMixin:
-    @validator("geometry")
+    @field_validator("geometry")
+    @classmethod
     def validate_geometry(cls, value):
         """Validates geometry"""
         if value:


### PR DESCRIPTION
## Summary
First incremental step on #256 — migrates `GeometryValidatorMixin`'s `geometry` validator from the deprecated Pydantic V1 `@validator` API to V2's `@field_validator`, adding the explicit `@classmethod` that V2 requires (V1 handled this implicitly).

Validator logic itself is unchanged — only the decorator mechanics.

This repo currently resolves Pydantic 2.12.3, and the old `@validator` syntax still works but raises `PydanticDeprecatedSince20` warnings, with removal planned for Pydantic V3. This PR is scoped to just this one validator, per the plan discussed in the issue — 8 more `@validator` usages remain in `src/validation/models.py` for follow-up PRs, along with a related `Field(..., example=...)` → `Field(..., json_schema_extra={...})` deprecation pattern noticed while testing.

## Test plan
- [x] Verified no `PydanticDeprecatedSince20` warning fires for this validator after the change (previously did)
- [x] `pytest tests/test_app.py` — 5 passed, 0 failed (remaining warnings are all from the other, not-yet-migrated validators/Fields in this file, unrelated to this change)
- [x] Confirmed the field_validator + classmethod pattern works correctly when defined on a mixin combined via multiple inheritance (`RawDataCurrentParamsBase(BaseModel, GeometryValidatorMixin)`), matching how this class is actually used

Closes part of #256 (first of several incremental PRs).