### PR TITLE
fix: migrate BaseModel to Pydantic V2 ConfigDict

### DIFF
--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Union
 # Third party imports
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
 from pydantic import BaseModel as PydanticModel
-from pydantic import Field, validator
+from pydantic import ConfigDict, Field, validator
 
 # Reader imports
 from src.config import (
@@ -46,11 +46,12 @@ def to_camel(string: str) -> str:
 
 
 class BaseModel(PydanticModel):
-    class Config:
-        alias_generator = to_camel
-        populate_by_name = True
-        use_enum_values = True
-        # extra = "forbid"
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        use_enum_values=True,
+        # extra="forbid"
+    )
 
 
 class RawDataOutputType(Enum):


### PR DESCRIPTION
## Summary
Second incremental step on #256 (see #307 for the first) — migrates the shared `BaseModel`'s class-based `Config` to Pydantic V2's `model_config = ConfigDict(...)` API.

Branched independently from `develop` rather than stacked on #307, so this is reviewable/mergeable on its own regardless of #307's status.

All settings keep the same names and behavior (`alias_generator`, `populate_by_name`, `use_enum_values`) — only the syntax moves from a nested class to a single class attribute.

Remaining scope for #256 (per maintainer's review on #307): 8 more `@validator` usages and 3 more `class Config` blocks in this same file, planned as further small incremental PRs.

## Test plan
- [x] Verified no class-based-config deprecation warning fires for `BaseModel` after the change
- [x] `pytest tests/test_app.py` — 5 passed, 0 failed