### PR TITLE
fix: migrate 5 single-field validators to Pydantic V2

### DIFF
--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Union
 # Third party imports
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
 from pydantic import BaseModel as PydanticModel
-from pydantic import Field, validator
+from pydantic import Field, field_validator, validator
 
 # Reader imports
 from src.config import (
@@ -203,7 +203,8 @@ class RawDataCurrentParamsBase(BaseModel, GeometryValidatorMixin):
         },
     )
 
-    @validator("geometry_type", allow_reuse=True)
+    @field_validator("geometry_type")
+    @classmethod
     def return_unique_value(cls, value):
         """return unique list"""
         if value:
@@ -368,7 +369,8 @@ class HDXModel(BaseModel):
         example="Sample notes to append",
     )
 
-    @validator("tags")
+    @field_validator("tags")
+    @classmethod
     def validate_tags(cls, value):
         """Validates tags if they are allowed from hdx allowed approved tags
 
@@ -427,7 +429,8 @@ class CategoryModel(BaseModel):
         example=["gpkg", "geojson"],
     )
 
-    @validator("types")
+    @field_validator("types")
+    @classmethod
     def validate_types(cls, value):
         """validates geom types
 
@@ -448,7 +451,8 @@ class CategoryModel(BaseModel):
                 )
         return value
 
-    @validator("formats")
+    @field_validator("formats")
+    @classmethod
     def validate_export_types(cls, value):
         """Validates export types if they are supported
 
@@ -554,7 +558,8 @@ class DatasetConfig(BaseModel):
         example="[{'url': 'https://something.org/datasetviz.html'}]",
     )
 
-    @validator("update_frequency")
+    @field_validator("update_frequency")
+    @classmethod
     def validate_frequency(cls, value):
         """Validates frequency
 


### PR DESCRIPTION
## Summary
Third incremental step on #256 (see #307, #308) — migrates the 5 remaining `@validator` usages that validate a single field with no cross-field access, to V2's `@field_validator`:

- `RawDataCurrentParamsBase.return_unique_value` (`geometry_type`)
- `HDXModel.validate_tags` (`tags`)
- `CategoryModel.validate_types` (`types`)
- `CategoryModel.validate_export_types` (`formats`)
- `DatasetConfig.validate_frequency` (`update_frequency`)

`allow_reuse=True` is dropped where present — verified V2's `field_validator` rejects it outright as an invalid kwarg, since V2 removed the duplicate-validator-name restriction it existed to work around.

Branched independently from `develop`, same as #308.

**Not included here, on purpose**: the remaining 3 `@validator` usages (lines 235, 332, 673 on develop) all read another field's value via a `values` parameter — real cross-field validation. That needs a materially different conversion (`field_validator(mode="before")` + `ValidationInfo.data` instead of a `values` dict, plus `validate_default=True` on the affected `Field` to replicate `always=True`) that I verified separately and want to give its own focused PR rather than mixing complexity levels here.

## Test plan
- [x] `pytest tests/test_app.py` — 5 passed, 0 failed
- [x] Deprecation warning count dropped by exactly 5, matching the 5 validators converted
- [x] Confirmed `allow_reuse=True` is rejected (not silently ignored) by V2's `field_validator`, so dropping it is the correct fix rather than a workaround