### PR TITLE
fix: migrate 3 cross-field validators to Pydantic V2

### DIFF
--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Union
 # Third party imports
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
 from pydantic import BaseModel as PydanticModel
-from pydantic import Field, validator
+from pydantic import Field, field_validator, validator
 
 # Reader imports
 from src.config import (
@@ -232,11 +232,12 @@ class RawDataCurrentParams(RawDataCurrentParamsBase):
     if ALLOW_BIND_ZIP_FILTER:
         bind_zip: Optional[bool] = True
 
-        @validator("bind_zip", allow_reuse=True)
-        def check_bind_option(cls, value, values):
+        @field_validator("bind_zip")
+        @classmethod
+        def check_bind_option(cls, value, info):
             """Checks if cloud optimized output format or geoJSON is selected along with bind to zip file"""
             if value is False:
-                if values.get("output_type") not in (
+                if info.data.get("output_type") not in (
                     (
                         [
                             RawDataOutputType.GEOJSON.value,
@@ -315,6 +316,7 @@ class StatsRequestParams(BaseModel, GeometryValidatorMixin):
         Union[Polygon, MultiPolygon, Feature, FeatureCollection]
     ] = Field(
         default=None,
+        validate_default=True,
         example={
             "type": "Polygon",
             "coordinates": [
@@ -329,12 +331,13 @@ class StatsRequestParams(BaseModel, GeometryValidatorMixin):
         },
     )
 
-    @validator("geometry", pre=True, always=True)
-    def set_geometry_or_iso3(cls, value, values):
+    @field_validator("geometry", mode="before")
+    @classmethod
+    def set_geometry_or_iso3(cls, value, info):
         """Either geometry or iso3 should be supplied."""
-        if value is not None and values.get("iso3") is not None:
+        if value is not None and info.data.get("iso3") is not None:
             raise ValueError("Only one of geometry or iso3 should be supplied.")
-        if value is None and values.get("iso3") is None:
+        if value is None and info.data.get("iso3") is None:
             raise ValueError("Either geometry or iso3 should be supplied.")
         return value
 
@@ -656,6 +659,7 @@ class DynamicCategoriesModel(CategoriesBase, GeometryValidatorMixin):
         Union[Polygon, MultiPolygon, Feature, FeatureCollection]
     ] = Field(
         default=None,
+        validate_default=True,
         example={
             "type": "Polygon",
             "coordinates": [
@@ -670,24 +674,25 @@ class DynamicCategoriesModel(CategoriesBase, GeometryValidatorMixin):
         },
     )
 
-    @validator("geometry", pre=True, always=True)
-    def set_geometry_or_iso3(cls, value, values):
+    @field_validator("geometry", mode="before")
+    @classmethod
+    def set_geometry_or_iso3(cls, value, info):
         """Either geometry or iso3 should be supplied."""
-        if value is not None and values.get("iso3") is not None:
+        if value is not None and info.data.get("iso3") is not None:
             raise ValueError("Only one of geometry or iso3 should be supplied.")
-        if value is None and values.get("iso3") is None:
+        if value is None and info.data.get("iso3") is None:
             raise ValueError("Either geometry or iso3 should be supplied.")
         if value is not None:
-            dataset = values.get("dataset")
-            if values.get("hdx_upload"):
-                for category in values.get("categories"):
+            dataset = info.data.get("dataset")
+            if info.data.get("hdx_upload"):
+                for category in info.data.get("categories"):
                     category_name, category_data = list(category.items())[0]
                     if category_data.hdx is None:
                         raise ValueError(f"HDX is missing for category {category}")
 
-            if dataset is None and values.get("hdx_upload"):
+            if dataset is None and info.data.get("hdx_upload"):
                 raise ValueError("Dataset config should be supplied for custom polygon")
-            if values.get("hdx_upload"):
+            if info.data.get("hdx_upload"):
                 for item in dataset:
                     if item is None:
                         raise ValueError(f"Missing, Dataset config : {item}")


### PR DESCRIPTION
## Summary

Converts the 3 remaining `@validator` usages in `src/validation/models.py` that read *other* fields via V1's `values` parameter (deliberately deferred out of #309 since they need the `mode="before"` + `info.data` treatment rather than a plain decorator swap):

- `RawDataCurrentParams.check_bind_option` (`bind_zip`)
- `StatsRequestParams.set_geometry_or_iso3` (`geometry`)
- `DynamicCategoriesModel.set_geometry_or_iso3` (`geometry` — this one also has extra HDX dataset/category cross-checks beyond the base geometry/iso3 logic)

`@validator(field, allow_reuse=True)` → `@field_validator(field)` + `@classmethod`; `values.get(...)` → `info.data.get(...)`.

### The `always=True` gotcha

The two `set_geometry_or_iso3` validators used `pre=True, always=True` in V1, so they run even when `geometry` is omitted (this is how the "either geometry or iso3, not neither" check works). V2's `field_validator` has no `always` equivalent — `mode="before"` alone does **not** run when the field is omitted and its default is used. Verified this with an isolated test before relying on it.

The correct V2 replacement is `validate_default=True` on the field's own `Field(...)` declaration, added here to both `geometry` fields. Re-verified behaviorally across all 4 cases (geometry-only, iso3-only, both supplied, neither supplied) that this reproduces the original V1 semantics exactly.

Part of the `pydantic` v1→v2 migration tracked in #256. Continues the incremental approach from #307/#308/#309.

## Test plan

- [x] `pytest tests/test_app.py` passes (5 passed)
- [x] No remaining deprecation warnings for these 3 validators
- [x] Isolated behavioral test of `StatsRequestParams`: neither/both/geometry-only/iso3-only all raise/pass exactly as before
- [x] Isolated behavioral test of `RawDataCurrentParams.check_bind_option`: disallowed output_type + bind_zip=False raises, allowed output_type + bind_zip=False passes, default bind_zip passes regardless of output_type
- [x] Isolated unit test of `DynamicCategoriesModel.set_geometry_or_iso3`'s extra HDX dataset-required-when-hdx_upload logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)