### PR TITLE
fix: migrate 3 response-model class Config blocks to ConfigDict

### DIFF
--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Union
 # Third party imports
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
 from pydantic import BaseModel as PydanticModel
-from pydantic import Field, validator
+from pydantic import ConfigDict, Field, validator
 
 # Reader imports
 from src.config import (
@@ -256,13 +256,14 @@ class SnapshotResponse(BaseModel):
     task_id: str
     track_link: str
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "task_id": "aa539af6-83d4-4aa3-879e-abf14fffa03f",
                 "track_link": "/tasks/status/aa539af6-83d4-4aa3-879e-abf14fffa03f/",
             }
         }
+    )
 
 
 class SnapshotTaskResult(BaseModel):
@@ -279,8 +280,8 @@ class SnapshotTaskResponse(BaseModel):
     status: str
     result: SnapshotTaskResult
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "id": "3fded368-456f-4ef4-a1b8-c099a7f77ca4",
                 "status": "SUCCESS",
@@ -294,13 +295,15 @@ class SnapshotTaskResponse(BaseModel):
                 },
             }
         }
+    )
 
 
 class StatusResponse(BaseModel):
     last_updated: str
 
-    class Config:
-        json_schema_extra = {"example": {"lastUpdated": "2022-06-27 19:59:24+05:45"}}
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"lastUpdated": "2022-06-27 19:59:24+05:45"}}
+    )
 
 
 class StatsRequestParams(BaseModel, GeometryValidatorMixin):


### PR DESCRIPTION
## Summary

Converts the remaining `class Config: json_schema_extra = {...}` blocks in `src/validation/models.py` to Pydantic V2's `model_config = ConfigDict(json_schema_extra={...})`:

- `SnapshotResponse`
- `SnapshotTaskResponse`
- `StatusResponse`

These are all simple, example-only `Config` blocks with no other settings, so the conversion is mechanical. `BaseModel`'s own `Config` (`alias_generator`/`populate_by_name`/`use_enum_values`) is handled separately in #308 and intentionally left untouched here to keep this PR isolated.

This is the last of the `class Config` blocks flagged as remaining scope for #256.

## Test plan

- [x] `pytest tests/test_app.py` passes (5 passed)
- [x] No remaining "class-based config is deprecated" warnings for these 3 classes
- [x] Confirmed each model's `model_json_schema()` still includes its `example` after the conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)