### PR TITLE
feat: merge multi-feature geometry input into a single polygon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.115.0
 uvicorn==0.24.0
 psycopg2==2.9.9
 geojson-pydantic==1.0.1
+shapely==2.1.2
 
 
 geojson==3.1.0

--- a/src/validation/models.py
+++ b/src/validation/models.py
@@ -25,6 +25,8 @@ from typing import Dict, List, Optional, Union
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
 from pydantic import BaseModel as PydanticModel
 from pydantic import Field, validator
+from shapely.geometry import mapping, shape
+from shapely.ops import unary_union
 
 # Reader imports
 from src.config import (
@@ -136,11 +138,20 @@ class GeometryValidatorMixin:
                         raise ValueError(
                             f"Feature Collection can't have {feature.type} , should be polygon/multipolygon"
                         )
-                if len(value.features) > 1:
-                    raise ValueError(
-                        "Feature collection with multiple features is not supported yet"
-                    )
-                return value.features[0].geometry
+                if len(value.features) == 1:
+                    return value.features[0].geometry
+                # Multiple Polygon/MultiPolygon features: merge into a single
+                # Polygon via their convex hull, so callers don't have to
+                # pre-extract/merge geometries themselves. Note this can
+                # enclose a larger area than the union of the input features
+                # (e.g. features far apart from each other), it's a
+                # deliberate simplification rather than exact per-feature
+                # extract generation.
+                shapes = [
+                    shape(feature.geometry.model_dump()) for feature in value.features
+                ]
+                merged_hull = unary_union(shapes).convex_hull
+                return Polygon(**mapping(merged_hull))
         return value
 
 


### PR DESCRIPTION
## Summary

Partially addresses #175.

`GeometryValidatorMixin.validate_geometry` previously rejected any `FeatureCollection` with more than one feature outright (`"Feature collection with multiple features is not supported yet"`), forcing every upstream caller to pre-extract/merge geometries themselves before calling `raw-data-api`.

Now, when a `FeatureCollection` has multiple `Polygon`/`MultiPolygon` features (still validated the same as before — non-polygon feature types are still rejected), they're merged via Shapely's `unary_union` and reduced to their convex hull, returned as a single `Polygon`. This is the approach @spwoodcock sketched in the issue thread — a deliberate simplification rather than generating extracts per-feature. The merged hull can enclose more area than the union of the inputs if features are far apart from each other; that's documented in a code comment at the call site.

Single-feature `FeatureCollection`, bare `Feature`, and bare `Polygon`/`MultiPolygon` inputs are all unchanged.

### What this doesn't do

Doesn't implement `GeometryCollection` support or the full [`geojson-aoi-parser`](https://github.com/hotosm/geojson-aoi-parser) integration also discussed in the issue. `geojson-aoi-parser` needs a live PostGIS connection internally, which isn't available at this synchronous Pydantic-validation layer without a bigger architectural change (passing DB access into validation, or moving validation later in the request flow). Scoping this PR to the Shapely-only approach that fits the existing validator as-is, and leaving the DB-aware integration as a separate follow-up if it's wanted.

Adds `shapely` as a new dependency (wasn't previously used directly in this repo).

## Test plan

- [x] Verified end-to-end against the real `RawDataCurrentParamsBase` model: multi-feature merge produces the expected convex-hull polygon.
- [x] Verified single-feature `FeatureCollection`, bare `Feature`, and bare `Polygon` inputs are all unchanged.
- [x] Verified a `FeatureCollection` containing a non-Polygon/MultiPolygon feature (e.g. `LineString`) is still rejected.
- [x] `pytest tests/test_app.py` passes (5 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)